### PR TITLE
dtb-qcom-image: use 4096-byte FAT sectors for UFS compatibility

### DIFF
--- a/recipes-kernel/images/dtb-el2-qcom-image.bb
+++ b/recipes-kernel/images/dtb-el2-qcom-image.bb
@@ -25,6 +25,10 @@ inherit image
 IMAGE_FSTYPES = "vfat"
 IMAGE_FSTYPES_DEBUGFS = ""
 
+# UFS requires logical sector size >= 4096; force 4096-byte sectors so UEFI
+# can read the FAT filesystem from the dtb_a partition.
+EXTRA_IMAGECMD:vfat = "-S 4096"
+
 ROOTFS_SIZE = "65536"
 
 LINGUAS_INSTALL = ""

--- a/recipes-kernel/images/dtb-qcom-image.bb
+++ b/recipes-kernel/images/dtb-qcom-image.bb
@@ -16,6 +16,10 @@ inherit image
 IMAGE_FSTYPES = "vfat"
 IMAGE_FSTYPES_DEBUGFS = ""
 
+# UFS requires logical sector size >= 4096; force 4096-byte sectors so UEFI
+# can read the FAT filesystem from the dtb_a partition.
+EXTRA_IMAGECMD:vfat = "-S 4096"
+
 ROOTFS_SIZE = "65536"
 
 LINGUAS_INSTALL = ""


### PR DESCRIPTION
## Summary

`dtb-qcom-image.bb` および `dtb-el2-qcom-image.bb` に `EXTRA_IMAGECMD:vfat = "-S 4096"` を追加する。

UFS ストレージは論理セクタサイズ ≥ 4096 バイトを要求する。これがないと UEFI が `dtb_a` パーティションの FAT ファイルシステムを読み取れず、起動時にデバイスツリーのロードに失敗する。

また、`pfr-2026-04-04-0` マージ (chromium symbol_level revert) も含む。

## 動作確認 ✅

RubikPi3 実機で確認済み。dtb.bin 書き込み後、デバイスツリーが正常にロードされ起動することを確認。

## 関連

- qlipfr PR: pf-robotics/qlipfr#11