### PR TITLE
Add pfr-camera-config: install camxoverridesettings.txt to /var/cache/camera/

### DIFF
--- a/recipes-pfr/pfr-camera-config/files/camxoverridesettings.txt
+++ b/recipes-pfr/pfr-camera-config/files/camxoverridesettings.txt
@@ -1,7 +1,18 @@
-; camxoverridesettings.txt
-; CamX override settings for PFR
-; This file is placed at /var/lib/camera/ and is writable at runtime.
-; Edits here survive OSTree updates (initial copy only; use C in tmpfiles.d).
-;
-; Example:
-; logInfoMask=0x1
+multiCameraLogicalXMLFile=kodiak_dc.xml
+enableNCSService=FALSE
+enableFeature2CTS=0
+dumpSensorEEPROMData=TRUE
+maxRAWSizes=2
+
+systemLogEnable=FALSE
+overrideLogLevels=0x00
+
+logWarningMask=0x0
+logEntryExitMask=0x0
+logCoreCfgMask=0x0
+logConfigMask=0x0
+logDumpMask=0x0
+logInfoMask=0x0
+logPerfInfoMask=0x0
+logVerboseMask=0x0
+logRequestMapping=FALSE

--- a/recipes-pfr/pfr-camera-config/files/camxoverridesettings.txt
+++ b/recipes-pfr/pfr-camera-config/files/camxoverridesettings.txt
@@ -1,0 +1,7 @@
+; camxoverridesettings.txt
+; CamX override settings for PFR
+; This file is placed at /var/lib/camera/ and is writable at runtime.
+; Edits here survive OSTree updates (initial copy only; use C in tmpfiles.d).
+;
+; Example:
+; logInfoMask=0x1

--- a/recipes-pfr/pfr-camera-config/pfr-camera-config.bb
+++ b/recipes-pfr/pfr-camera-config/pfr-camera-config.bb
@@ -1,0 +1,28 @@
+SUMMARY = "PFR camera configuration files"
+DESCRIPTION = "Installs camxoverridesettings.txt to /var/lib/camera/ via tmpfiles.d"
+LICENSE = "CLOSED"
+
+SRC_URI = "file://camxoverridesettings.txt"
+
+S = "${WORKDIR}"
+
+inherit allarch
+
+do_install() {
+    # Install the file to the read-only rootfs as the source template.
+    install -d ${D}${datadir}/camera
+    install -m 0644 ${WORKDIR}/camxoverridesettings.txt ${D}${datadir}/camera/
+
+    # Install tmpfiles.d rule to create /var/lib/camera/ and copy the file
+    # on first boot (C = copy only if destination does not yet exist).
+    install -d ${D}${libdir}/tmpfiles.d
+    cat > ${D}${libdir}/tmpfiles.d/pfr-camera-config.conf << 'EOF'
+d /var/lib/camera 0755 root root -
+C /var/lib/camera/camxoverridesettings.txt - - - - /usr/share/camera/camxoverridesettings.txt
+EOF
+}
+
+FILES:${PN} = "\
+    ${datadir}/camera/camxoverridesettings.txt \
+    ${libdir}/tmpfiles.d/pfr-camera-config.conf \
+"

--- a/recipes-pfr/pfr-camera-config/pfr-camera-config.bb
+++ b/recipes-pfr/pfr-camera-config/pfr-camera-config.bb
@@ -17,8 +17,8 @@ do_install() {
     # on first boot (C = copy only if destination does not yet exist).
     install -d ${D}${libdir}/tmpfiles.d
     cat > ${D}${libdir}/tmpfiles.d/pfr-camera-config.conf << 'EOF'
-d /var/lib/camera 0755 root root -
-C /var/lib/camera/camxoverridesettings.txt - - - - /usr/share/camera/camxoverridesettings.txt
+d /var/cache/camera 0755 root root -
+C /var/cache/camera/camxoverridesettings.txt - - - - /usr/share/camera/camxoverridesettings.txt
 EOF
 }
 

--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -20,6 +20,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     first-login \
     rubikpi3-thermal \
     pfr-ansible-bootstrap \
+    pfr-camera-config \
 "
 
 IMAGE_INSTALL:append = " \


### PR DESCRIPTION
## 概要

- `pfr-camera-config` レシピを新規追加
- `camxoverridesettings.txt` を `/var/cache/camera/` に配置する（ansible-first-time-setup の var ロールと同一パス・内容）
- OSTree 対応のため `tmpfiles.d` 経由でインストール:
  - `/usr/share/camera/camxoverridesettings.txt` に静的ファイルを配置（読み取り専用 rootfs）
  - 初回起動時に `/var/cache/camera/` ディレクトリを作成し、ファイルをコピー
  - `C` ディレクティブ使用（宛先が存在しない場合のみコピー → 編集内容は OSTree 更新後も保持）
- `qcom-multimedia-image` に `pfr-camera-config` を追加
- fb-progress ブランチ (`a6622d55`) ベースにリベース済み

## テスト

- [ ] ビルド確認 (`bitbake pfr-camera-config`)
- [ ] `/var/cache/camera/camxoverridesettings.txt` が初回起動後に存在すること
- [ ] ファイルを編集後、OSTree 更新しても内容が保持されること