### PR TITLE
kernel+initramfs: FDE Phase 1 scaffolding

### DIFF
--- a/dynamic-layers/sota/recipes-sota/ostree-initrd/files/pfr-luks-unlock.sh
+++ b/dynamic-layers/sota/recipes-sota/ostree-initrd/files/pfr-luks-unlock.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# PFR Full-Disk Encryption unlock hook.
+#
+# Called from ostree-initrd init.sh before the otaroot mount.
+# Looks for a LUKS2 header on /dev/disk/by-partlabel/system; if present,
+# tries to unlock it to /dev/mapper/otaroot. Key sources in priority:
+#   1. PFR_FDE_KEY_FD  file descriptor passed from QTEE helper  (Phase 2)
+#   2. /run/pfr-fde/master.key  in-memory tmpfs key file         (Phase 2)
+#   3. Passphrase prompt on /dev/console                        (Phase 1)
+#
+# If no LUKS header is found, exits 0 so the boot proceeds unchanged
+# (backward compatibility with un-encrypted rollout).
+
+set -u
+
+log() { echo "pfr-luks-unlock: $*" >&2; }
+
+SYSTEM_DEV="/dev/disk/by-partlabel/system"
+MAPPER_NAME="otaroot"
+
+# Backward-compat bailout: if no system partition label yet, skip silently.
+if [ ! -e "${SYSTEM_DEV}" ]; then
+    log "no ${SYSTEM_DEV}; skipping (unexpected, but letting boot continue)"
+    exit 0
+fi
+
+if ! cryptsetup isLuks "${SYSTEM_DEV}" 2>/dev/null; then
+    log "no LUKS header on ${SYSTEM_DEV}; skipping (unencrypted rollout)"
+    exit 0
+fi
+
+# Already open from a prior invocation?
+if [ -e "/dev/mapper/${MAPPER_NAME}" ]; then
+    log "${MAPPER_NAME} already open"
+    exit 0
+fi
+
+try_keyfile() {
+    kf="$1"
+    [ -r "${kf}" ] || return 1
+    log "trying key from ${kf}"
+    cryptsetup open --type luks2 --key-file "${kf}" \
+        "${SYSTEM_DEV}" "${MAPPER_NAME}"
+}
+
+try_passphrase() {
+    log "LUKS passphrase required for ${SYSTEM_DEV}"
+    # Prompt on the console so operators can unlock during recovery.
+    cryptsetup open --type luks2 "${SYSTEM_DEV}" "${MAPPER_NAME}" \
+        </dev/console >/dev/console 2>&1
+}
+
+# Phase 2 (QTEE) integration point: a helper service would populate
+# /run/pfr-fde/master.key on a tmpfs before this script runs.
+if try_keyfile /run/pfr-fde/master.key; then
+    log "unlocked via tmpfs key"
+    shred -u /run/pfr-fde/master.key 2>/dev/null || rm -f /run/pfr-fde/master.key
+    exit 0
+fi
+
+# Phase 1 fallback: passphrase.
+if try_passphrase; then
+    log "unlocked via passphrase"
+    exit 0
+fi
+
+log "FAILED to unlock ${SYSTEM_DEV}"
+exit 1

--- a/dynamic-layers/sota/recipes-sota/ostree-initrd/ostree-initrd.bbappend
+++ b/dynamic-layers/sota/recipes-sota/ostree-initrd/ostree-initrd.bbappend
@@ -1,3 +1,18 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " file://pfr-luks-unlock.sh"
+
 do_install:append:qcom() {
+    install -Dm 0755 ${WORKDIR}/pfr-luks-unlock.sh ${D}/usr/lib/ostree-initrd/pfr-luks-unlock.sh
+
+    # Insert the LUKS unlock hook before the first (top-level, column 0)
+    # occurrence of the otaroot mount. init.sh has a second mount call
+    # inside an || { } retry block indented with spaces, so anchor with ^.
+    sed -i '/^mount "$ostree_sysroot" \/sysroot/i /usr/lib/ostree-initrd/pfr-luks-unlock.sh || bail_out "LUKS unlock failed"' ${D}/init
+
+    # Enable inlinecrypt on the otaroot mount. Must run AFTER the insert
+    # above since this rewrites the same line pattern.
     sed -i 's|mount "$ostree_sysroot" /sysroot|mount -o inlinecrypt "$ostree_sysroot" /sysroot|g' ${D}/init
 }
+
+FILES:${PN} += " /usr/lib/ostree-initrd/pfr-luks-unlock.sh "

--- a/recipes-kernel/linux/linux-qcom-custom/pfr-fde.cfg
+++ b/recipes-kernel/linux/linux-qcom-custom/pfr-fde.cfg
@@ -1,0 +1,13 @@
+# PFR Full-Disk Encryption kernel config fragment.
+# Enables dm-crypt + LUKS2-friendly crypto primitives for cryptsetup.
+CONFIG_DM_CRYPT=y
+CONFIG_DM_INTEGRITY=y
+CONFIG_CRYPTO_XTS=y
+CONFIG_CRYPTO_AES=y
+CONFIG_CRYPTO_SHA256=y
+CONFIG_CRYPTO_SHA512=y
+CONFIG_CRYPTO_USER_API_SKCIPHER=y
+CONFIG_CRYPTO_USER_API_HASH=y
+# Keyring-based key passing into dm-crypt (used for QTEE integration later).
+CONFIG_KEYS=y
+CONFIG_ENCRYPTED_KEYS=y

--- a/recipes-kernel/linux/linux-qcom-custom_6.6.bb
+++ b/recipes-kernel/linux/linux-qcom-custom_6.6.bb
@@ -28,6 +28,7 @@ SRC_URI = "file://kernel-6.6;protocol=file;name=git \
            file://0004-QCLINUX-net-stmmac-Add-EEPROM-support-to-driver.patch \
            file://0005-kernel-arm64-dts-qcom-enable-EEPROM-Client-Driver.patch \
            file://0006-kernel-config-qcom-enable-AT24-EEPROM-driver.patch \
+           file://pfr-fde.cfg \
            "
 
 S = "${WORKDIR}/kernel-6.6"
@@ -48,6 +49,9 @@ KERNEL_CONFIG_FRAGMENTS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'smac
 
 # Add support for RUBIK Pi 3
 KERNEL_CONFIG_FRAGMENTS:append = " ${S}/arch/arm64/configs/rubikpi3.config"
+
+# PFR Full-Disk Encryption (dm-crypt / LUKS / kernel keyring)
+KERNEL_CONFIG_FRAGMENTS:append = " ${WORKDIR}/pfr-fde.cfg"
 
 # List of kernel modules that will be auto-loaded for Qualcomm platforms.
 


### PR DESCRIPTION
## 概要

Full-Disk Encryption (FDE) の Phase 1 scaffolding です。`pf-robotics/qlipfr` 側の親 PR (ブランチ `pfr-scarthgap-2026-04-21-fde`) から参照される submodule 側のコミットです。

- カーネル config fragment `pfr-fde.cfg` を追加し `CONFIG_DM_CRYPT` / `CONFIG_CRYPTO_XTS` / `CONFIG_KEYS` / `CONFIG_ENCRYPTED_KEYS` 等を有効化
- OSTree initramfs に LUKS unlock フック `pfr-luks-unlock.sh` をインストール
- `ostree-initrd.bbappend` で `init.sh` を編集し、`mount LABEL=otaroot /sysroot` の直前にフック呼出しを挿入 (GNU sed `^mount` anchor で二重刺さりを回避、手元で dry-run 済み)
- 鍵取得優先順: `/run/pfr-fde/master.key` (Phase 2 の QTEE 引継ぎポイント) → コンソール passphrase (Phase 1 fallback)

**後方互換**: `/dev/disk/by-partlabel/system` に LUKS2 ヘッダが無ければフックは no-op で抜けるため、既存の暗号化なし機は起動挙動が変わりません。

全体設計は親 PR の \`docs/security.md\` と [SREVO-2972](https://linear.app/preferredrobotics/issue/SREVO-2972) を参照。

## テスト
- [ ] ローカル bitbake で \`initramfs-ostree-image-qcm6490-idp.cpio.gz\` が生成される
- [ ] 生成された initramfs の cpio 展開で \`/usr/lib/ostree-initrd/pfr-luks-unlock.sh\` が入っている
- [ ] 展開した \`/init\` の \`mount "\$ostree_sysroot" /sysroot\` 直前にフック呼出しがある
- [ ] 生成カーネルで \`zcat /proc/config.gz | grep -E "DM_CRYPT|CRYPTO_XTS"\` が一致 (実機)
- [ ] 暗号化なし build を tflash 後に通常起動できる (後方互換検証、実機)