### PR TITLE
initramfs: install cryptsetup and keyutils for FDE

### DIFF
--- a/recipes-core/images/initramfs-ostree-image.bbappend
+++ b/recipes-core/images/initramfs-ostree-image.bbappend
@@ -1,0 +1,5 @@
+PACKAGE_INSTALL:append = " \
+    cryptsetup \
+    keyutils \
+    e2fsprogs-tune2fs \
+"


### PR DESCRIPTION
## 概要

FDE Phase 1 scaffolding の distro 側。`pf-robotics/qlipfr` の親 PR (ブランチ `pfr-scarthgap-2026-04-21-fde`) から参照される submodule コミットです。

- `initramfs-ostree-image` に `cryptsetup` / `keyutils` / `e2fsprogs-tune2fs` を追加
- meta-rubikpi-bsp 側 `pfr-scarthgap-2026-04-21-fde-bsp` の `pfr-luks-unlock.sh` が必要とするツール一式

全体設計は親 PR の \`docs/security.md\` と [SREVO-2972](https://linear.app/preferredrobotics/issue/SREVO-2972) を参照。

## テスト
- [ ] \`bitbake -e initramfs-ostree-image | grep PACKAGE_INSTALL\` に cryptsetup / keyutils / e2fsprogs-tune2fs が入っている
- [ ] 生成された initramfs を展開して \`/usr/sbin/cryptsetup\` が存在する
- [ ] initramfs サイズの増加が許容範囲内 (目安: +5MB 以内)