### PR TITLE
qcom-camera-server: pre-create /tmp/socket via tmpfiles.d

### DIFF
--- a/recipes-multimedia/camera-server/files/cam-server-tmpfiles.conf
+++ b/recipes-multimedia/camera-server/files/cam-server-tmpfiles.conf
@@ -1,0 +1,8 @@
+# cam-server.service runs as User=system,Group=video and its first
+# ExecStartPre `/bin/mkdir -p /tmp/socket/cam_server` is unprivileged.
+# If any other process creates /tmp/socket as root before cam-server
+# starts, the unprivileged mkdir fails with permission denied and the
+# service cannot start. Pre-create both directories with the expected
+# ownership at boot so the ExecStartPre is always idempotent.
+d /tmp/socket 0755 system video -
+d /tmp/socket/cam_server 0775 system video -

--- a/recipes-multimedia/camera-server/qcom-camera-server.bb
+++ b/recipes-multimedia/camera-server/qcom-camera-server.bb
@@ -18,7 +18,8 @@ SRCBRANCH  = "le-services.lnx.1.0.r1-rel"
 SRCREV     = "bc8d77091b55ce79b8010e8d27f6c3009cdfa9bd"
 
 SRC_URI  = "${SRCPROJECT};branch=${SRCBRANCH};destsuffix=le-camera-server \
-            file://cam-server-env"
+            file://cam-server-env \
+            file://cam-server-tmpfiles.conf"
 
 S = "${WORKDIR}/le-camera-server"
 
@@ -48,6 +49,11 @@ do_install:append () {
         # enable the service for multi-user.target
         ln -sf /etc/systemd/system/cam-server.service \
            ${D}/etc/systemd/system/multi-user.target.wants/cam-server.service
+        # Pre-create /tmp/socket{,/cam_server} via systemd-tmpfiles so the
+        # unit's unprivileged ExecStartPre mkdir cannot race with other
+        # processes creating /tmp/socket as root.
+        install -D -m 0644 ${WORKDIR}/cam-server-tmpfiles.conf \
+            ${D}${nonarch_libdir}/tmpfiles.d/cam-server.conf
     fi
     install ${WORKDIR}/cam-server-env -D ${D}/${sysconfdir}/cam-server-env
 }
@@ -55,6 +61,7 @@ do_install:append () {
 FILES:${PN}-cam-server-dbg = "${bindir}/.debug/cam-server"
 FILES:${PN}-cam-server     = "${bindir}/cam-server"
 FILES:${PN}-cam-server    += "/etc/systemd/system/"
+FILES:${PN}-cam-server    += "${nonarch_libdir}/tmpfiles.d/cam-server.conf"
 
 FILES:${PN}-libqmmf_recorder_client-dbg    = "${libdir}/.debug/libqmmf_recorder_client.*"
 FILES:${PN}-libqmmf_recorder_client        = "${libdir}/libqmmf_recorder_client.so.*"


### PR DESCRIPTION
## 概要

`cam-server.service` の起動順序依存バグを修正する。tmpfiles.d で boot 早期に `/tmp/socket{,/cam_server}` を `system:video` 所有で作成することで、unit file の非特権 ExecStartPre mkdir が他プロセスとの競合で permission denied を起こす問題を回避する。

## 背景

`qcom-camera-server.bb` が ship する unit file の最初の ExecStartPre が **非特権** mkdir:

```
[Service]
User=system
Group=video
ExecStartPre=/bin/mkdir -p /tmp/socket/cam_server          ← 非特権 (User=system)
ExecStartPre=+/bin/chmod 0775 /tmp/socket/cam_server       ← 特権
```

他プロセス (docker bind-mount setup, 他のサービス) が `/tmp/socket` を `root:root` で先に作ると、system ユーザーが subdir を作れず:

```
mkdir: cannot create directory '/tmp/socket/cam_server': Permission denied
cam-server.service: Control process exited, code=exited, status=1/FAILURE
```

cam-server が起動しないと、ROS qtiqmmfsrc プラグインが GLib `qmmfsrc->context != NULL` アサーションで SIGSEGV し、vision コンテナが再起動ループに入る。

実機 (PFR sr24) で再現した。

## 変更内容

- `recipes-multimedia/camera-server/files/cam-server-tmpfiles.conf` 新規:
  ```
  d /tmp/socket 0755 system video -
  d /tmp/socket/cam_server 0775 system video -
  ```
- `qcom-camera-server.bb` の `do_install:append` で `/usr/lib/tmpfiles.d/cam-server.conf` に install
- `FILES:${PN}-cam-server` に追加

## なぜ /usr/lib/tmpfiles.d か

OSTree base image では `/usr` は read-only で OTA 間で確実に保持される。recipe 由来の base config は `/etc/tmpfiles.d` (admin override) より `/usr/lib/tmpfiles.d` (base config) が適切。