### PR TITLE
qcom-camera-server: ship tmpfiles.d drop-in on ${PN}

### DIFF
--- a/recipes-multimedia/camera-server/qcom-camera-server.bb
+++ b/recipes-multimedia/camera-server/qcom-camera-server.bb
@@ -62,6 +62,11 @@ FILES:${PN}-cam-server-dbg = "${bindir}/.debug/cam-server"
 FILES:${PN}-cam-server     = "${bindir}/cam-server"
 FILES:${PN}-cam-server    += "/etc/systemd/system/"
 FILES:${PN}-cam-server    += "${nonarch_libdir}/tmpfiles.d/cam-server.conf"
+# ${PN}-cam-server is declared via FILES but never added to PACKAGES, so its
+# files fall through to ${PN}. Default FILES:${PN} covers /etc via ${sysconfdir}
+# but not /usr/lib/tmpfiles.d, so the tmpfiles.d drop-in was tripping the
+# installed-vs-shipped QA check. Claim it on ${PN} explicitly.
+FILES:${PN}              += "${nonarch_libdir}/tmpfiles.d/cam-server.conf"
 
 FILES:${PN}-libqmmf_recorder_client-dbg    = "${libdir}/.debug/libqmmf_recorder_client.*"
 FILES:${PN}-libqmmf_recorder_client        = "${libdir}/libqmmf_recorder_client.so.*"


### PR DESCRIPTION
## 概要
- `qcom-camera-server` の `do_package` が `installed-vs-shipped` QA で fatal 失敗していた問題を修正
- PR #14 で追加した `/usr/lib/tmpfiles.d/cam-server.conf` を `FILES:${PN}-cam-server` にだけ足していたが、このサブパッケージは `PACKAGES` に含まれていない (`PACKAGES` の上書きも `PACKAGE_BEFORE_PN` も無い) ため、実体として生成されず、ファイルは `${PN}` にフォールスルーする
- default `FILES:${PN}` は `${sysconfdir}` を含むので `/etc/systemd/system/` は偶然拾えていたが、`/usr/lib/tmpfiles.d/*` は default に含まれないため tmpfiles drop-in が孤児ファイルになり QA が発火していた
- `FILES:${PN} += "${nonarch_libdir}/tmpfiles.d/cam-server.conf"` を明示追加して解消

## 背景
- qlipfr の main CI (`layers: bump meta-rubikpi-bsp for cam-server tmpfiles.d fix (#30)`) が本件で失敗
- https://github.com/pf-robotics/qlipfr/actions/runs/24715777564

## テスト
- [ ] qlipfr 側で本コミットに bump した PR で CI 通過